### PR TITLE
Tuned various battle mechanics

### DIFF
--- a/CommonStatic.java
+++ b/CommonStatic.java
@@ -568,38 +568,39 @@ public class CommonStatic {
 	 * Gets the minimum position value for a data enemy.
 	 */
 	public static float dataEnemyMinPos(MaModel model) {
-		int y = model.confs[0][2];
-		float z = (float) model.parts[0][8] / model.ints[0];
-		return 2.5f * (float) Math.floor(y * z);
+		int x = ((model.confs[0][2] - model.parts[0][6]) * model.parts[0][8]) / model.ints[0];
+		return 2.5f * x;
 	}
 
 	/**
 	 * Gets the minimum position value for a custom enemy.
 	 */
 	public static float customEnemyMinPos(MaModel model) {
-		int y = -model.parts[0][6];
-		float z = (float) model.parts[0][8] / model.ints[0];
-		return 2.5f * (float) Math.floor(y * z);
+		int x = ((model.confs[0][2] - model.parts[0][6]) * model.parts[0][8]) / model.ints[0];
+		return 2.5f * x;
 	}
 
 	/**
 	 * Gets the minimum position value for a data cat unit.
 	 */
 	public static int dataFormMinPos(MaModel model) {
-		return (int) Math.max(0, 5 * Math.round((9.0 / 5.0) * model.confs[1][2] - 1));
+		int x = ((model.confs[1][2] - model.parts[0][6]) * model.parts[0][8]) / model.ints[0];
+		return 5 * x;
 	}
 
 	/**
 	 * Gets the minimum position value for a custom cat unit.
 	 */
 	public static int customFormMinPos(MaModel model) {
-		return (int) Math.max(0, 5 * Math.round((9.0 / 5.0) * model.parts[0][6] - 1));
+		int x = ((model.confs[1][2] - model.parts[0][6]) * model.parts[0][8]) / model.ints[0];
+		return 5 * x;
 	}
 
 	/**
 	 * Gets the boss spawn point for a castle.
+	 * Basically 3200 + yx/10 + 0.9*z but the 0.9*z part appears to use a quirky rounding
 	 */
 	public static float bossSpawnPoint(int y, int z) {
-		return (3200 + (float) (y * z / 10) + Math.round(0.25f * Math.round(3.6f * z))) / 4f;
+		return (float) (3200 + (y * z / 10) + (9 * z + 8 * z % 10) / 10) / 4f;
 	}
 }

--- a/battle/CannonLevelCurve.java
+++ b/battle/CannonLevelCurve.java
@@ -60,15 +60,12 @@ public class CannonLevelCurve extends Data {
         int min = curve[MIN_VALUE][index];
         int max = curve[MAX_VALUE][index];
 
-        int minLevel;
         float v;
 
-        if (index == 0) {
-            minLevel = part == PART.CANNON ? 1 : 0;
-            v = min + (max - min) * (level - minLevel) / 9f;
+        if (level <= 10 && part == PART.CANNON) {
+            v = min + (max - min) * (level - 1) / 9f;
         } else {
-            minLevel = index * 10;
-            v = min + (max - min) * (level - minLevel) / 10f;
+            v = min + (max - min) * (level % 10) / 10f;
         }
 
         return v;

--- a/battle/StageBasis.java
+++ b/battle/StageBasis.java
@@ -143,12 +143,7 @@ public class StageBasis extends BattleObj {
 		canon = new Cannon(this, nyc[0], nyc[1], nyc[2]);
 		conf = ints;
 
-		if(st.minSpawn <= 0 || st.maxSpawn <= 0)
-			respawnTime = 1;
-		else if(st.minSpawn == st.maxSpawn)
-			respawnTime = st.minSpawn;
-		else
-			respawnTime = st.minSpawn + (int) ((st.maxSpawn - st.minSpawn) * r.nextDouble());
+		respawnTime = 0;
 
 		if ((conf[0] & 1) > 0)
 			work_lv = 8;
@@ -177,7 +172,7 @@ public class StageBasis extends BattleObj {
 	 * returns visual money.
 	 */
 	public int getMoney() {
-		return (int) Math.floor(money / 100.0);
+		return money / 100;
 	}
 
 	/**
@@ -456,7 +451,10 @@ public class StageBasis extends BattleObj {
 
 			EUnit su = f.getEntity(this, null, true);
 
-			su.added(-1, Math.min(ubase.pos, summoner[i][j].lastPosition + SPIRIT_SUMMON_RANGE));
+			// summoner.pos and not summoner.lastPosition
+			// actions are processed before the update so it's automatic for the spirit to spawn relative to the summoner last pos
+			// 800 + range and not ebase.pos + range because it doesn't respond to entity enemy base
+			su.added(-1, Math.max(800 + su.data.getRange(), Math.min(summoner[i][j].pos + SPIRIT_SUMMON_RANGE, ubase.pos)));
 
 			le.add(su);
 			le.sort(Comparator.comparingInt(e -> e.layer));
@@ -534,6 +532,118 @@ public class StageBasis extends BattleObj {
 			er.updateCopy((StageBasis) hardCopy(this), hardCopy(er.map.get(this)));
 	}
 
+	// -------------------- DEV_ONLY -------------------- //
+	private final int[][] transcription = {
+			{ 215,0},
+			{ 613,11},
+			{1029,2},
+			{ 947,0},
+			{1214,1},
+			{1251,9},
+			{ 537,2},
+			{ 623,1},
+			{ 848,4},
+			{ 670,2},
+			{1425,6},
+			{ 884,2},
+			{1318,9},
+			{ 720,3},
+			{ 201,1},
+			{ 238,0},
+			{ 428,1},
+			{ 407,2},
+			{ 796,4},
+			{ 264,1},
+			{ 798,5},
+			{ 724,3},
+			{ 397,2},
+			{1181,10},
+			{2221,11},
+			{1494,2},
+			{1317,1},
+			{1391,4},
+			{1234,9},
+			{ 898,1},
+			{ 850,2},
+			{ 863,3},
+			{ 825,6},
+			{ 540,0},
+			{ 899,4},
+			{ 328,0},
+			{ 553,1},
+			{ 498,2},
+			{1260,0},
+			{1259,8},
+			{ 494,1},
+			{2929,5},
+			{2512,9},
+			{1556,4},
+			{1463,3},
+			{ 931,6},
+			{ 401,0},
+			{ 489,1},
+			{ 746,2},
+			{ 685,0},
+			{ 725,1},
+			{1799,5},
+			{1280,6},
+			{ 778,4},
+			{1322,7},
+			{ 779,5},
+			{ 104,10},
+			{ 802,4},
+			{ 536,2},
+			{ 570,1},
+			{ 630,0},
+			{ 833,3},
+			{ 449,1},
+			{ 755,2},
+			{ 869,4},
+			{ 976,5},
+			{ 647,2},
+			{1176,3},
+			{1084,4},
+			{1095,0},
+			{1209,9},
+			{ 349,1},
+			{ 704,2},
+			{ 520,0},
+			{ 764,5},
+			{ 719,2},
+			{1946,4},
+			{1389,3},
+			{1046,6},
+			{ 741,2},
+			{2606,1},
+			{2652,7},
+			{1757,9},
+			{ 992,5},
+			{ 772,4},
+			{ 798,6},
+			{ 679,10},
+			{1727,8},
+			{ 894,3},
+			{ 986,5},
+			{1067,6},
+			{ 754,5},
+			{ 452,1},
+			{ 383,2},
+			{ 816,5},
+			{1224,6},
+			{1040,5},
+			{1491,5},
+			{2304,5},
+			{3499,2},
+			{3295,1},
+			{3450,0},
+			{3863,1},
+			{3998,2},
+			{3807,9},
+			{3429,1}
+	};
+	private int tranIdx = 0;
+	// -------------------- DEV_ONLY -------------------- //
+
 	/**
 	 * process actions and add enemies from stage first then update each entity
 	 * and receive attacks then excuse attacks and do post update then delete dead
@@ -546,6 +656,26 @@ public class StageBasis extends BattleObj {
 			bgEffect.initialize(st.len, battleHeight, midH, bg);
 			bgEffectInitialized = true;
 		}
+
+		// -------------------- DEV_ONLY -------------------- //
+		if(true) {
+			if (time == 1)
+				tranIdx = 0;
+			if (tranIdx < transcription.length) {
+				if (money / 100 == transcription[tranIdx][0]) {
+					if(transcription[tranIdx][1] < 10) {
+						act_spawn(transcription[tranIdx][1] / 5, transcription[tranIdx][1] % 5, true);
+					} else {
+						if(transcription[tranIdx][1] == 10)
+							act_can();
+						else
+							act_mon();
+					}
+					tranIdx++;
+				}
+			}
+		}
+		// -------------------- DEV_ONLY -------------------- //
 
 		if (buttonDelay > 0 && --buttonDelay == 0) {
 			act_spawn(selectedUnit[0], selectedUnit[1], true);
@@ -571,16 +701,16 @@ public class StageBasis extends BattleObj {
 		}
 
 		if (s_stop == 0 || (ebase.getAbi() & AB_TIMEI) != 0) {
-			ebase.preUpdate();
-			ebase.update();
+			//ebase.update();
+			//ebase.update2();
 		}
 
 		if (s_stop == 0) {
 			if(bgEffect != null)
 				bgEffect.update(st.len, battleHeight, midH);
 
-			ubase.preUpdate();
-			ubase.update();
+			//ubase.update();
+			//ubase.update2();
 
 			int allow = st.max - entityCount(1);
 			if (respawnTime <= 0 && active && allow > 0) {
@@ -641,7 +771,8 @@ public class StageBasis extends BattleObj {
 			if (active)
 				est.update();
 
-			canon.update();
+			// Cannon should be updated after entities
+			// canon.update();
 
 			if (sniper != null && active)
 				sniper.update();
@@ -673,6 +804,8 @@ public class StageBasis extends BattleObj {
 
 			n_inten--;
 		}
+
+		canon.update();
 
 		if (s_stop == 0) {
 			lea.forEach(EAnimCont::update);
@@ -852,14 +985,24 @@ public class StageBasis extends BattleObj {
 		}
 	}
 
-	private void updateEntities(boolean time) {
-		for (int i = 0; i < le.size(); i++)
-			if (time || (le.get(i).getAbi() & AB_TIMEI) != 0)
-				le.get(i).preUpdate();
+	/*
+	private void updateEntitiesOld(boolean time) {
 
+		le.sort(Comparator.comparingInt(e -> e.dire));
+
+		ebase.update();
+		ubase.update();
 		for (int i = 0; i < le.size(); i++)
 			if (time || (le.get(i).getAbi() & AB_TIMEI) != 0)
 				le.get(i).update();
+
+		ebase.update2();
+		ubase.update2();
+		for (int i = 0; i < le.size(); i++)
+			if (time || (le.get(i).getAbi() & AB_TIMEI) != 0)
+				le.get(i).update2();
+
+		le.sort(Comparator.comparingInt(e -> e.layer));
 
 		for (int i = 0; i < tlw.size(); i++)
 			if (time || tlw.get(i).IMUTime())
@@ -868,6 +1011,47 @@ public class StageBasis extends BattleObj {
 		for (int i = 0; i < lw.size(); i++)
 			if (time || lw.get(i).IMUTime())
 				lw.get(i).update();
+	}
+	 */
+
+	private void updateEntities(boolean time) {
+
+		for (int i = 0; i < tlw.size(); i++)
+			if (time || tlw.get(i).IMUTime())
+				tlw.get(i).update();
+
+		for (int i = 0; i < lw.size(); i++)
+			if (time || lw.get(i).IMUTime())
+				lw.get(i).update();
+
+		le.sort(Comparator.comparingInt(e -> e.dire));
+
+		ebase.update();
+		ubase.update();
+		for (int i = 0; i < le.size(); i++)
+			if (time || (le.get(i).getAbi() & AB_TIMEI) != 0)
+				le.get(i).update();
+
+		for (int i = 0; i < le.size(); i++) {
+			if (le.get(i).dire == 1) continue;
+			if (time || (le.get(i).getAbi() & AB_TIMEI) != 0)
+				le.get(i).update2();
+		}
+
+		la.forEach(AttackAb::capture);
+		la.forEach(AttackAb::excuse);
+		la.removeIf(a -> a.duration <= 0);
+
+		ebase.update2();
+		ubase.update2();
+		for (int i = 0; i < le.size(); i++) {
+			if (le.get(i).dire == -1) continue;
+			if (time || (le.get(i).getAbi() & AB_TIMEI) != 0)
+				le.get(i).update2();
+		}
+
+		le.sort(Comparator.comparingInt(e -> e.layer));
+
 	}
 
 	private void updateEntitiesAnimation(boolean time) {

--- a/battle/StageBasis.java
+++ b/battle/StageBasis.java
@@ -658,7 +658,7 @@ public class StageBasis extends BattleObj {
 		}
 
 		// -------------------- DEV_ONLY -------------------- //
-		if(true) {
+		if(false) {
 			if (time == 1)
 				tranIdx = 0;
 			if (tranIdx < transcription.length) {

--- a/battle/Treasure.java
+++ b/battle/Treasure.java
@@ -233,10 +233,7 @@ public class Treasure extends Data {
 		int t = tech[LV_BASE];
 		int base = t < 6 ? t * 1000 : t < 8 ? 5000 + (t - 5) * 2000 : 9000 + (t - 7) * 3000;
 		base += trea[T_BASE] * 70;
-		if (bslv[0] > 10)
-			base += 36000 + 4000 * (bslv[0] - 10);
-		else
-			base += 3600 * bslv[0];
+		base += (bslv[0] - 1) * 4000;
 		return base * (100 + b.getInc(C_BASE)) / 100;
 	}
 

--- a/battle/attack/AttackSimple.java
+++ b/battle/attack/AttackSimple.java
@@ -71,19 +71,34 @@ public class AttackSimple extends AttackAb {
 			List<AbEntity> ents = new ArrayList<>();
 			ents.add(capt.get(0));
 
-			double dis = Math.abs(pos - ents.get(0).pos);
+			if (dire == 1) {
 
-			for (AbEntity e: capt) {
-				double targetDis = Math.abs(pos - e.pos);
+				double leftMost = ents.get(0).pos;
 
-				if (targetDis < dis) {
-					ents.clear();
-					ents.add(e);
-
-					dis = targetDis;
-				} else if (targetDis == dis) {
-					ents.add(e);
+				for (AbEntity e: capt) {
+					if (e.pos < leftMost) {
+						leftMost = e.pos;
+						ents.clear();
+						ents.add(e);
+					} else if (e.pos == leftMost) {
+						ents.add(e);
+					}
 				}
+
+			} else {
+
+				double rightMost = ents.get(0).pos;
+
+				for (AbEntity e: capt) {
+					if (e.pos > rightMost) {
+						rightMost = e.pos;
+						ents.clear();
+						ents.add(e);
+					} else if (e.pos == rightMost) {
+						ents.add(e);
+					}
+				}
+
 			}
 
 			capt.clear();
@@ -135,7 +150,7 @@ public class AttackSimple extends AttackAb {
 			float p0 = model.getPos() + dire * addp;
 			// generate a wave when hits somebody
 
-			ContWaveDef wave = new ContWaveDef(new AttackWave(attacker, this, p0, wid, WT_WAVE), p0, layer, true);
+			ContWaveDef wave = new ContWaveDef(new AttackWave(attacker, this, p0, wid, WT_WAVE), p0, layer, -3);
 
 			if(attacker != null) {
 				attacker.summoned.add(wave);
@@ -148,7 +163,7 @@ public class AttackSimple extends AttackAb {
 			float addp = (dire == 1 ? W_E_INI : W_U_INI) + wid / 2f;
 			float p0 = model.getPos() + dire * addp;
 
-			ContWaveDef wave = new ContWaveDef(new AttackWave(attacker, this, p0, wid, WT_MINI), p0, layer, false);
+			ContWaveDef wave = new ContWaveDef(new AttackWave(attacker, this, p0, wid, WT_MINI), p0, layer, -1);
 
 			if(attacker != null) {
 				attacker.summoned.add(wave);

--- a/battle/attack/AttackVolcano.java
+++ b/battle/attack/AttackVolcano.java
@@ -38,11 +38,10 @@ public class AttackVolcano extends AttackAb {
 	public void excuse() {
 		process();
 
+		volcTime--;
 		if (volcTime == 0) {
 			volcTime = VOLC_ITV;
 			vcapt.clear();
-		} else {
-			volcTime--;
 		}
 
 		atk = rawAtk;

--- a/battle/attack/ContExtend.java
+++ b/battle/attack/ContExtend.java
@@ -7,22 +7,24 @@ import common.system.fake.FakeGraphics;
 
 public class ContExtend extends ContAb {
 
-    private final int itv, move, rep, end;
-    private int t, rem, rept, start;
+    private final int itv, move, rep;
+    private final float end;
+    private int t, rem, rept;
+    private float start;
     private final AttackWave atk;
     private boolean tempAtk;
 
     /**
      * conf: range, move, itrv, tot, rept,layer
      */
-    public ContExtend(AttackSimple as, float p, int... conf) {
-        super(as.model.b, p, conf[5]);
-        move = conf[1];
-        itv = conf[2];
+    public ContExtend(AttackSimple as, float p, float wid, int... conf) {
+        super(as.model.b, p, conf[4]);
+        move = conf[0];
+        itv = conf[1];
         t = itv;
-        rem = conf[3];
-        rep = conf[4];
-        start = end = conf[0] / 2;
+        rem = conf[2];
+        rep = conf[3];
+        start = end = wid / 2;
         rept = rep > 0 ? rep : -1;
         atk = new AttackWave(as.attacker, as, 0, 0, WT_MOVE);
     }

--- a/battle/attack/ContVolcano.java
+++ b/battle/attack/ContVolcano.java
@@ -119,10 +119,10 @@ public class ContVolcano extends ContAb {
 		if (t >= aliveTime + VOLC_POST + VOLC_PRE) {
 			activate = false;
 		} else {
-			if (t >= VOLC_PRE && t < VOLC_PRE + aliveTime)
+			t++;
+			if (t >= VOLC_PRE && t <= VOLC_PRE + aliveTime)
 				sb.getAttack(v);
 			anim.update(false);
-			t++;
 		}
 	}
 

--- a/battle/attack/ContWaveAb.java
+++ b/battle/attack/ContWaveAb.java
@@ -19,13 +19,12 @@ public abstract class ContWaveAb extends ContAb {
 	protected int maxt;
 	protected boolean tempAtk;
 
-	protected ContWaveAb(AttackWave a, float p, EAnimD<?> ead, int layer, boolean delay) {
+	protected ContWaveAb(AttackWave a, float p, EAnimD<?> ead, int layer, int delay) {
 		super(a.model.b, p, layer);
 		atk = a;
 		anim = ead;
 		maxt = anim.len();
-		if (delay)
-			t = -2;
+		t = delay;
 	}
 
 	@Override

--- a/battle/attack/ContWaveCanon.java
+++ b/battle/attack/ContWaveCanon.java
@@ -14,14 +14,16 @@ public class ContWaveCanon extends ContWaveAb {
 
 	private final int canid;
 
+	// used only by normal and zombie cannon
 	public ContWaveCanon(AttackWave a, float p, int id) {
-		super(a, p, CommonStatic.getBCAssets().atks[id].getEAnim(NyType.ATK), 9, true);
+		super(a, p, CommonStatic.getBCAssets().atks[id].getEAnim(NyType.ATK), 9, -3);
 		canid = id;
 		soundEffect = SE_CANNON[canid][1];
 
 		waves = new HashSet<>();
 		waves.add(this);
-		maxt = (W_TIME + 1) * (a.proc.WAVE.lv + 1) + (anim.len() - (W_TIME + 3));
+		// hitframe offset + (waves attack period) * (number of waves - 1) + ending linger
+		maxt = 3 + (W_TIME + 1) * (a.proc.WAVE.lv + 1 - 1) + 4;
 
 		if (id != 0) {
 			anim.setTime(1);
@@ -30,7 +32,7 @@ public class ContWaveCanon extends ContWaveAb {
 	}
 
 	public ContWaveCanon(AttackWave a, float p, int id, int maxTime, Set<ContWaveAb> waves) {
-		super(a, p, CommonStatic.getBCAssets().atks[id].getEAnim(NyType.ATK), 9, false);
+		super(a, p, CommonStatic.getBCAssets().atks[id].getEAnim(NyType.ATK), 9, 0);
 		canid = id;
 		soundEffect = SE_CANNON[canid][1];
 
@@ -102,7 +104,7 @@ public class ContWaveCanon extends ContWaveAb {
 
 	@Override
 	protected void nextWave() {
-		float np = pos - 405;
+		float np = pos - NYRAN[canid];
 		new ContWaveCanon(new AttackWave(atk.attacker, atk, np, NYRAN[canid]), np, canid, maxt - t, waves);
 	}
 

--- a/battle/attack/ContWaveDef.java
+++ b/battle/attack/ContWaveDef.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 public class ContWaveDef extends ContWaveAb {
 
-	protected ContWaveDef(AttackWave a, float p, int layer, boolean delay) {
+	protected ContWaveDef(AttackWave a, float p, int layer, int delay) {
 		super(a, p, (a.dire == 1 ? a.waveType == WT_MINI ? effas().A_E_MINIWAVE : effas().A_E_WAVE : a.waveType == WT_MINI ? effas().A_MINIWAVE : effas().A_WAVE).getEAnim(DefEff.DEF), layer, delay);
 		soundEffect = SE_WAVE;
 
@@ -20,7 +20,7 @@ public class ContWaveDef extends ContWaveAb {
 		waves.add(this);
 	}
 
-	protected ContWaveDef(AttackWave a, float p, int layer, boolean delay, Set<ContWaveAb> waves) {
+	protected ContWaveDef(AttackWave a, float p, int layer, int delay, Set<ContWaveAb> waves) {
 		super(a, p, (a.dire == 1 ? a.waveType == WT_MINI ? effas().A_E_MINIWAVE : effas().A_E_WAVE : a.waveType == WT_MINI ? effas().A_MINIWAVE : effas().A_WAVE).getEAnim(DefEff.DEF), layer, delay);
 		soundEffect = SE_WAVE;
 
@@ -39,7 +39,7 @@ public class ContWaveDef extends ContWaveAb {
 		// guessed wave block time compared from BC
 		if (t == 0)
 			CommonStatic.setSE(soundEffect);
-		if (t >= (isMini ? 1 : 2) && t <= attack) {
+		if (t <= attack) {
 			atk.capture();
 			for (AbEntity e : atk.capt)
 				if ((e.getAbi() & AB_WAVES) > 0) {
@@ -51,7 +51,7 @@ public class ContWaveDef extends ContWaveAb {
 		}
 		if (!activate)
 			return;
-		if (t == (isMini ? W_MINI_TIME - 1 : W_TIME)) {
+		if (t == (isMini ? W_MINI_TIME : W_TIME)) {
 			if (isMini && atk.proc.MINIWAVE.lv > 0)
 				nextWave();
 			else if (!isMini && atk.getProc().WAVE.lv > 0)
@@ -79,7 +79,7 @@ public class ContWaveDef extends ContWaveAb {
 		int dire = atk.model.getDire();
 		float np = pos + W_PROG * dire;
 		int wid = dire == 1 ? W_E_WID : W_U_WID;
-		new ContWaveDef(new AttackWave(atk.attacker, atk, np, wid), np, layer, false, waves);
+		new ContWaveDef(new AttackWave(atk.attacker, atk, np, wid), np, layer, 0, waves);
 	}
 
 	@Override

--- a/battle/entity/AbEntity.java
+++ b/battle/entity/AbEntity.java
@@ -50,9 +50,9 @@ public abstract class AbEntity extends BattleObj {
 
 	public abstract int touchable();
 
-	public abstract void preUpdate();
-
 	public abstract void update();
+
+	public abstract void update2();
 
 	public abstract void updateAnimation();
 }

--- a/battle/entity/Cannon.java
+++ b/battle/entity/Cannon.java
@@ -141,7 +141,7 @@ public class Cannon extends AtkModelAb {
             exta.update(false);
 
         if (anim == null && atka == null && exta == null) {
-            if (id > 2 && id < 5) {
+            if (id == 3 || id == 4) {
                 pos = b.ubase.pos;
                 for (Entity e : b.le)
                     if (e.dire == -1 && e.pos < pos && (e.touchable() & (TCH_N | TCH_KB)) != 0)
@@ -159,12 +159,12 @@ public class Cannon extends AtkModelAb {
             // wall canon
             Form f = Identifier.parseInt(339, Unit.class).get().forms[0];
             EAnimU enter = f.getEAnim(UType.ENTER);
-            enter.setTime(0);
+            enter.setTime(1);
             wall = new EUnit(b, f.du, enter, 1);
             b.le.add(wall);
             b.le.sort(Comparator.comparingInt(e -> e.layer));
-            wall.added(-1, (int) (pos + 100)); // guessed distance from enemy compared from BC
-            preTime = (int) b.b.t().getCannonMagnification(id, Data.BASE_WALL_ALIVE_TIME) + enter.len();
+            wall.added(-1, (int) (pos + 100)); // guessed distance from enemy compared from BC // update: checked with GG, correct
+            preTime = (int) b.b.t().getCannonMagnification(id, Data.BASE_WALL_ALIVE_TIME) + enter.len() - 1;
         }
 
         if (preTime == 0 || --preTime != 0)
@@ -181,13 +181,25 @@ public class Cannon extends AtkModelAb {
         Proc proc = Proc.blank();
         ArrayList<Trait> traits = new ArrayList<>();
 
+        /**
+         * Cannons can be grouped into 2 main type: waved and localized
+         * waved: basic, slow, zombie, curse
+         * localized: wall, freeze, water, blast
+         *
+         * NYRAN for localized cannons represents directly the aoe of the cannon
+         * NYRAN for waved cannons has 2 different meanings:
+         *       - basic and zombie cannons use NYRAN for the aoe of each single wave
+         *             NYRAN is then also used for wave-0 offset
+         *       - slow and curse cannons use NYRAN for wave-0 offset
+         *             spe is indeed used for the aoe of their single wave
+         */
         if (id == 0) {
             // basic canon
             traits.add(UserProfile.getBCData().traits.get(TRAIT_TOT));
             proc.WAVE.lv = b.b.t().tech[LV_CRG] + 2;
             proc.SNIPER.prob = 1;
             float wid = NYRAN[0];
-            float p = b.ubase.pos - wid / 2 + 100;
+            float p = (float) (b.ubase.pos - 332.5 + wid / 2);
             int atk = b.b.t().getCanonAtk();
             AttackCanon eatk = new AttackCanon(this, atk, traits, 0, proc, 0, 0, 1);
             new ContWaveCanon(new AttackWave(eatk.attacker, eatk, p, wid, WT_CANN | WT_WAVE), p, 0);
@@ -195,49 +207,48 @@ public class Cannon extends AtkModelAb {
             // slow canon
             traits.add(UserProfile.getBCData().traits.get(TRAIT_TOT));
             proc.SLOW.time = (int) (b.b.t().getCannonMagnification(id, Data.BASE_SLOW_TIME) * (100 + b.b.getInc(C_SLOW)) / 100);
-            int wid = NYRAN[1];
-            int spe = 137;
+            float wid = NYRAN[1];
+            int spe = 150;
             float p = b.ubase.pos - wid / 2f + spe;
             AttackCanon eatk = new AttackCanon(this, 0, traits, 0, proc, 0, 0, 1);
-            new ContExtend(eatk, p, wid, spe, 1, 31, 0, 9);
+            new ContExtend(eatk, p, wid, spe, 1, 32, 0, 9);
         } else if (id == 3) {
             // freeze canon
             traits.add(UserProfile.getBCData().traits.get(TRAIT_TOT));
-            duration = 1;
+            duration = 1 + 10;
             proc.STOP.time = (int) (b.b.t().getCannonMagnification(id, Data.BASE_TIME) * (100 + b.b.getInc(C_STOP)) / 100.0);
             int atk = (int) (b.b.t().getCanonAtk() * b.b.t().getCannonMagnification(id, Data.BASE_ATK_MAGNIFICATION) / 100.0);
-            int rad = NYRAN[3] / 2;
+            float rad = NYRAN[3] / 2;
             b.getAttack(new AttackCanon(this, atk, traits, 0, proc, pos - rad, pos + rad, duration));
         } else if (id == 4) {
             // water canon
             traits.add(UserProfile.getBCData().traits.get(TRAIT_TOT));
-            duration = 1;
+            duration = 1 + 10;
             proc.CRIT.mult = -(int) (b.b.t().getCannonMagnification(id, Data.BASE_HEALTH_PERCENTAGE));
-            int rad = NYRAN[4] / 2;
+            float rad = NYRAN[4] / 2;
             b.getAttack(new AttackCanon(this, 1, new ArrayList<>(), 0, proc, pos - rad, pos + rad, duration));
         } else if (id == 5) {
             // zombie canon
             traits.add(UserProfile.getBCData().traits.get(TRAIT_TOT));
             proc.WAVE.lv = b.b.t().tech[LV_CRG] + 2;
-            float wid = NYRAN[5];
             proc.STOP.time = (int) (b.b.t().getCannonMagnification(id, Data.BASE_TIME) * (100 + b.b.getInc(C_STOP)) / 100);
             proc.SNIPER.prob = 1;
-            float p = b.ubase.pos - wid / 2 + 100;
             traits.set(0, UserProfile.getBCData().traits.get(TRAIT_ZOMBIE));
+            float wid = NYRAN[5];
+            float p = (float) (b.ubase.pos - 332.5 + wid / 2);
             AttackCanon eatk = new AttackCanon(this, 0, traits, AB_ONLY | AB_ZKILL | AB_CKILL, proc, 0, 0, 1);
             new ContWaveCanon(new AttackWave(eatk.attacker, eatk, p, wid, WT_CANN | WT_WAVE), p, 5);
         } else if (id == 6) {
-            // barrier canon
-            // guessed hit box time
+            // blast canon
             traits.addAll(UserProfile.getAll(Identifier.DEF, Trait.class));
-            duration = 11;
+            duration = 1 + 10;
             proc.BREAK.prob = 1;
             proc.KB.dis = KB_DIS[INT_KB];
             proc.KB.time = KB_TIME[INT_KB];
             int atk = (int) (b.b.t().getCanonAtk() * b.b.t().getCannonMagnification(id, Data.BASE_ATK_MAGNIFICATION) / 100.0);
             float rad = b.b.t().getCannonMagnification(id, Data.BASE_RANGE);
             float newPos = getBreakerSpawnPoint(pos, rad);
-            b.getAttack(new AttackCanon(this, atk, traits, AB_CKILL, proc, newPos - rad, newPos - 1, duration));
+            b.getAttack(new AttackCanon(this, atk, traits, AB_CKILL, proc, newPos - rad, newPos, duration));
 
             atka = CommonStatic.getBCAssets().atks[id].getEAnim(NyType.ATK);
             exta = CommonStatic.getBCAssets().atks[id].getEAnim(NyType.EXT);
@@ -245,11 +256,11 @@ public class Cannon extends AtkModelAb {
             // curse cannon
             traits.add(UserProfile.getBCData().traits.get(TRAIT_TOT));
             proc.CURSE.time = (int) b.b.t().getCannonMagnification(id, Data.BASE_CURSE_TIME);
-            int wid = NYRAN[7];
-            int spe = 137;
+            float wid = NYRAN[7];
+            int spe = 150;
             float p = b.ubase.pos - wid / 2f + spe;
             AttackCanon eatk = new AttackCanon(this, 0, traits, 0, proc, 0, 0, 1);
-            new ContExtend(eatk, p, wid, spe, 1, 31, 0, 9);
+            new ContExtend(eatk, p, wid, spe, 1, 32, 0, 9);
         }
     }
 

--- a/battle/entity/ECastle.java
+++ b/battle/entity/ECastle.java
@@ -141,7 +141,7 @@ public class ECastle extends AbEntity {
 	}
 
 	@Override
-	public void preUpdate() {
+	public void update2() {
 
 	}
 

--- a/battle/entity/EUnit.java
+++ b/battle/entity/EUnit.java
@@ -248,11 +248,9 @@ public class EUnit extends Entity {
 	}
 
 	@Override
-	protected boolean updateMove(float maxl, float extmov) {
-		if (status[P_SLOW][0] == 0)
-			extmov = (float) (extmov + data.getSpeed() * basis.b.getInc(C_SPE) / 200.0);
-
-		return super.updateMove(maxl, extmov);
+	protected void updateMove(float extmov) {
+		extmov = (float) (data.getSpeed() * basis.b.getInc(C_SPE) / 50) / 4f;
+		super.updateMove(extmov);
 	}
 
 	private int getOrbAtk(ArrayList<Trait> trait, MaskAtk matk) {

--- a/battle/entity/Entity.java
+++ b/battle/entity/Entity.java
@@ -585,6 +585,10 @@ public abstract class Entity extends AbEntity {
 				dead = soul.len();
 				CommonStatic.setSE(SE_DEATH_SURGE);
 			} else {
+				// converge souls layer: death on the same frame = same soul height
+				// still not sure how this precisely work in BC, it seems to have exceptions
+				e.layer = 0;
+
 				Soul s = Identifier.get(e.data.getDeathAnim());
 				dead = s == null ? 0 : (soul = s.getEAnim(UType.SOUL)).len();
 			}
@@ -842,12 +846,8 @@ public abstract class Entity extends AbEntity {
 		}
 
 		private void kbmove(float mov) {
-			if (mov < 0)
-				e.updateMove(-mov, -mov);
-			else {
-				float lim = e.getLim();
-				e.pos -= Math.min(mov, lim) * e.dire;
-			}
+			float lim = e.getLim();
+			e.pos -= Math.min(mov, lim) * e.dire;
 		}
 
 		/**
@@ -863,7 +863,7 @@ public abstract class Entity extends AbEntity {
 					return;
 				}
 
-				if ((e.getAbi() & AB_GLASS) > 0 && e.atkm.atkTime == 0 && e.atkm.loop == 0) {
+				if ((e.getAbi() & AB_GLASS) > 0 && e.atkm.atkTime - 1 == 0 && e.atkm.loop == 0) {
 					e.kill(KillMode.SELF_DESTRUCT);
 
 					return;
@@ -1114,7 +1114,7 @@ public abstract class Entity extends AbEntity {
 		private void doRevive(int c) {
 			int deadAnim = minRevTime();
 			EffAnim<ZombieEff> ea = effas().A_ZOMBIE;
-			deadAnim += ea.getEAnim(ZombieEff.REVIVE).len();
+			deadAnim += ea.getEAnim(ZombieEff.REVIVE).len() - 1;
 			e.status[P_REVIVE][1] = deadAnim;
 			int maxR = maxRevHealth();
 			e.health = e.maxH * maxR / 100;
@@ -1225,7 +1225,7 @@ public abstract class Entity extends AbEntity {
 					anim.corpse = ea.getEAnim(ZombieEff.DOWN);
 					anim.corpse.setTime(0);
 				}
-				if (status[P_REVIVE][1] == ea.getEAnim(ZombieEff.REVIVE).len()) {
+				if (status[P_REVIVE][1] == ea.getEAnim(ZombieEff.REVIVE).len() - 2) {
 					anim.corpse = ea.getEAnim(ZombieEff.REVIVE);
 					anim.corpse.setTime(0);
 				}
@@ -1828,7 +1828,7 @@ public abstract class Entity extends AbEntity {
 		}
 
 		float f = getFruit(atk.trait, atk.dire, 1);
-		float time = atk instanceof AttackCanon ? 1 : 1 + f * 0.2f / 3;
+		float time = atk.origin instanceof AttackCanon ? 1 : 1 + f * 0.2f / 3;
 		float dist = 1 + f * 0.1f;
 
 		if (atk.getProc().STOP.time != 0 || atk.getProc().STOP.prob > 0) {
@@ -2150,7 +2150,7 @@ public abstract class Entity extends AbEntity {
 
 		kb.doInterrupt();
 
-		if ((getAbi() & AB_GLASS) > 0 && atkm.atkTime == 0 && kbTime == 0 && atkm.loop == 0)
+		if ((getAbi() & AB_GLASS) > 0 && atkm.atkTime - 1 == 0 && kbTime == 0 && atkm.loop == 0)
 			kill(KillMode.SELF_DESTRUCT);
 
 		// update ZKill
@@ -2278,13 +2278,6 @@ public abstract class Entity extends AbEntity {
 		return (kbTime == 0 ? n : TCH_KB) | ex;
 	}
 
-	@Override
-	public void preUpdate() {
-		// if this entity is in kb state, do kbmove()
-		if (kbTime > 0)
-			kb.updateKB();
-	}
-
 	/**
 	 * Remove existing proc to this entity
 	 */
@@ -2297,42 +2290,72 @@ public abstract class Entity extends AbEntity {
 				status[REMOVABLE_PROC[i]][0] = 1;
 	}
 
+	private boolean walking = true;
+	private boolean burrowing = false;
+
 	/**
-	 * update the entity. order of update: <br>
-	 *  move -> KB -> revive -> burrow -> wait -> attack
+	 * update the entity. order of update:
+	 *  1st iteration:   KB -> proc -> check touch to move -> revive -> update burrow
+	 *  2ns iteration:   check touch to validate walking -> start burrow -> attack
 	 */
 	@Override
 	public void update() {
+		// if this entity is in kb state, do kbmove()
+		if (kbTime > 0)
+			kb.updateKB();
+
 		// update proc effects
 		updateProc();
 		barrier.update();
 
-		boolean nstop = status[P_STOP][0] == 0;
-		canBurrow |= atkm.loop < data.getAtkLoop() - 1;
-
 		boolean canAct = kbTime == 0 && anim.anim.type != UType.ENTER;
 
-		// do move check if available, move if possible
-		if (canAct && !acted && atkm.atkTime == 0 && status[P_REVIVE][1] == 0) {
+		// move if possible
+		// walking modifier in update2: delaying to the next frame the movement of entities that resumed walking
+		if (canAct && walking) {
 			checkTouch();
 
-			if (!touch && nstop) {
+			if (!touch && status[P_STOP][0] == 0) {
+				updateMove(0);
+
 				if (health > 0)
 					anim.setAnim(UType.WALK, true);
 
-				updateMove(-1, 0);
 			}
 		}
 
 		// update revive status, mark acted
 		zx.updateRevive();
 
-		// check touch after KB or move
-		checkTouch();
+		if(burrowing)
+			updateBurrow();
+	}
+
+	@Override
+	public void update2() {
+
+		boolean nstop = status[P_STOP][0] == 0;
+		canBurrow |= atkm.loop < data.getAtkLoop() - 1;
+
+		boolean canAct = kbTime == 0 && anim.anim.type != UType.ENTER;
+
+		// check touch after KB or move, validate walking
+		walking = false;
+		if (canAct && !acted && atkm.atkTime == 0 && status[P_REVIVE][1] == 0) {
+			checkTouch();
+
+			// being stopped shouldn't invalidate walking status, entities will move in the same frame freeze proc ends
+			if (!touch) {
+				if (health > 0) {
+					walking = true;
+					anim.setAnim(UType.WALK, true);
+				}
+			}
+		}
 
 		// update burrow state if not stopped
-		if (nstop && canBurrow)
-			updateBurrow();
+		if (nstop && canBurrow && !burrowing && !acted && kbTime == 0 && touch && status[P_BURROW][0] != 0)
+			startBurrow();
 
 		canAct &= kbTime == 0;
 
@@ -2383,13 +2406,13 @@ public abstract class Entity extends AbEntity {
 			if (crit > 0)
 				ans = (int) (ans * 0.01 * crit);
 			else if (crit < 0)
-				ans = (int) Math.ceil(health * crit / -100.0);
+				ans = (int) Math.max(1, health * crit / -100);
 			else
 				ans = ans > 0 ? 1 : 0;
 		else if (crit > 0)
 			ans = (int) (ans * 0.01 * crit);
 		else if (crit < 0)
-			ans = (int) Math.ceil(health * 0.001);
+			ans = (int) Math.max(1, health / 1000);
 		return ans;
 	}
 
@@ -2412,42 +2435,41 @@ public abstract class Entity extends AbEntity {
 
 	/**
 	 * move forward <br>
-	 * maxl: max distance to move <br>
-	 * extmov: distance try to add to this movement return false when movement reach
-	 * endpoint
+	 * extmov: speedup combo extra distance
 	 */
-	protected boolean updateMove(float maxl, float extmov) {
+	protected void updateMove(float extmov) {
 		if (moved)
 			canBurrow = true;
 		moved = true;
 
-		float mov = status[P_SLOW][0] > 0 ? 0.25f : data.getSpeed() * 0.5f;
+		if (cantGoMore())
+			return;
 
-		if (status[P_SPEED][0] > 0 && status[P_SLOW][0] <= 0) {
-			if (status[P_SPEED][2] == 0) {
-				mov += status[P_SPEED][1] * 0.5f;
-			} else if (status[P_SPEED][2] == 1) {
-				mov = mov * (100 + status[P_SPEED][1]) / 100;
-			} else if (status[P_SPEED][2] == 2) {
-				mov = status[P_SPEED][1] * 0.5f;
+		if(status[P_SLOW][0] > 0) {
+
+			pos += 0.25f * dire;
+
+		} else {
+
+			float mov = data.getSpeed() * 0.5f;
+
+			if (status[P_SPEED][0] > 0) {
+				if (status[P_SPEED][2] == 0) {
+					mov += status[P_SPEED][1] * 0.5f;
+				} else if (status[P_SPEED][2] == 1) {
+					mov = mov * (100 + status[P_SPEED][1]) / 100;
+				} else if (status[P_SPEED][2] == 2) {
+					mov = status[P_SPEED][1] * 0.5f;
+				}
 			}
+
+			pos += (mov + extmov) * dire;
+
 		}
-
-		if (cantGoMore()) {
-			mov = 0;
-		}
-
-		mov += extmov;
-
-		if(maxl > 0)
-			mov = Math.min(mov, maxl);
-
-		pos += mov * dire;
 
 		if (kbTime == 0)
 			lastPosition = pos;
 
-		return maxl > mov;
 	}
 
 	/**
@@ -2455,13 +2477,10 @@ public abstract class Entity extends AbEntity {
 	 * @return True if the unit is in a position it can no longer move any further
 	 */
 	private boolean cantGoMore() {
-		if (status[P_SPEED][0] == 0)
-			return false;
-
 		if (dire == 1) {
-			return pos <= 0;
-		} else {
 			return pos >= basis.st.len;
+		} else {
+			return pos <= 0;
 		}
 	}
 
@@ -2543,20 +2562,22 @@ public abstract class Entity extends AbEntity {
 		return traitType() != dire;
 	}
 
+	private void startBurrow() {
+		float bpos = basis.getBase(dire).pos;
+		boolean ntbs = (bpos - pos) * dire > data.touchBase();
+		if (ntbs) {
+			// setup burrow state
+			burrowing = true;
+			status[P_BURROW][0]--;
+			status[P_BURROW][2] = anim.setAnim(UType.BURROW_DOWN, false) - 1;
+			kbTime = -2;
+		}
+	}
+
 	/**
 	 * update burrow state
 	 */
 	private void updateBurrow() {
-		if (!acted && kbTime == 0 && touch && status[P_BURROW][0] != 0) {
-			float bpos = basis.getBase(dire).pos;
-			boolean ntbs = (bpos - pos) * dire > data.touchBase();
-			if (ntbs) {
-				// setup burrow state
-				status[P_BURROW][0]--;
-				status[P_BURROW][2] = anim.setAnim(UType.BURROW_DOWN, true);
-				kbTime = -2;
-			}
-		}
 		if (!acted && kbTime == -2) {
 			acted = true;
 			// burrow down
@@ -2572,12 +2593,17 @@ public abstract class Entity extends AbEntity {
 		if (!acted && kbTime == -3) {
 			// move underground
 			float oripos = pos;
-			updateMove(0, 0);
-			bdist -= (pos - oripos) * dire;
-			if (bdist < 0 || (basis.getBase(dire).pos - pos) * dire - data.touchBase() <= 0) {
+			if (bdist < 0) {
 				bdist = 0;
 				kbTime = -4;
-				status[P_BURROW][2] = anim.setAnim(UType.BURROW_UP, true) - 2;
+				status[P_BURROW][2] = anim.setAnim(UType.BURROW_UP, false);
+			} else if ((basis.getBase(dire).pos - pos) * dire - data.touchBase() <= 0) {
+				bdist = 0;
+				kbTime = -4;
+				status[P_BURROW][2] = anim.setAnim(UType.BURROW_UP, true) - 1;
+			} else {
+				updateMove(0);
+				bdist -= (pos - oripos) * dire;
 			}
 		}
 		if (!acted && kbTime == -4) {
@@ -2586,8 +2612,11 @@ public abstract class Entity extends AbEntity {
 			status[P_BURROW][2]--;
 			if (data.getResurface() != null && anim.anim.len() - status[P_BURROW][2] == data.getResurface().pre)
 				basis.getAttack(aam.getAttack(data.getAtkCount() + 3));
-			if (status[P_BURROW][2] <= 0)
+			if (status[P_BURROW][2] <= 0) {
 				kbTime = 0;
+				burrowing = false;
+			}
+
 		}
 
 	}

--- a/battle/entity/Sniper.java
+++ b/battle/entity/Sniper.java
@@ -21,7 +21,7 @@ public class Sniper extends AtkModelAb {
 	private final EAnimD<?> atka = effas().A_SNIPER.getEAnim(SniperEff.ATK);
 	private int coolTime = SNIPER_CD, preTime = 0, atkTime = 0;
 	private Entity target;
-	public boolean enabled = true, canDo = true;
+	public boolean enabled = true;
 	public double pos, layer, height, bulletX, targetAngle = 0, cannonAngle = 0, bulletAngle = 0;
 	public final BattleField bf; //Used for replay pos/siz gathering
 
@@ -98,20 +98,21 @@ public class Sniper extends AtkModelAb {
 	}
 
 	public void update() {
-		if (canDo && b.ubase.health <= 0) {
-			canDo = false;
+		if (!enabled || b.ubase.health <= 0) {
+			return;
 		}
 
-		if (enabled && coolTime > 0 && preTime == 0 && atkTime == 0) {
+		if (coolTime > 0 && preTime == 0 && atkTime == 0) {
 			coolTime--;
 		}
 
-		if (coolTime == 0 && enabled && pos > 0 && canDo) {
+		if (coolTime == 0 && pos > 0) {
 			if(Math.abs(targetAngle - cannonAngle) < 1) {
 				coolTime = SNIPER_CD + 1;
 				preTime = SNIPER_PRE;
 				atkTime = atka.len();
 				atka.setup();
+				atka.update(false);
 				anim.setup();
 			} else {
 				coolTime++;

--- a/util/Data.java
+++ b/util/Data.java
@@ -1565,7 +1565,7 @@ public class Data {
 	public static final short W_E_WID = 500;
 	public static final short W_U_WID = 400;
 	public static final byte W_TIME = 3;
-	public static final byte W_MINI_TIME = 2; // mini wave spawn interval
+	public static final byte W_MINI_TIME = 1; // mini wave spawn interval
 	public static final byte E_IMU = -1;
 	public static final byte E_IWAVE = -2;
 	public static final byte E_SWAVE = -3;
@@ -1578,12 +1578,12 @@ public class Data {
 	public static final byte VOLC_POST = 10; // volcano post-atk
 	public static final byte VOLC_SE = 30; // volcano se loop duration
 
-	public static final byte[] NYPRE = new byte[] { 18, 2, -1, 28, 37, 18, 10, 2 };// not sure, 10f for bblast
-	public static final short[] NYRAN = new short[] { 710, 600, -1, 500, 500, 710, 100, 600 };// not sure
-	public static final short SNIPER_CD = 300;// not sure
-	public static final byte SNIPER_PRE = 10;// not sure
+	public static final byte[] NYPRE = new byte[] { 18, 1, -1, 27, 37, 18, 10, 1 };
+	public static final float[] NYRAN = new float[] { 400, 82.5f, -1, 500, 500, 400, 100, 82.5f };
+	public static final short SNIPER_CD = 300;
+	public static final byte SNIPER_PRE = 10;
 	public static final float SNIPER_POS = 442.5f;
-	public static final byte REVIVE_SHOW_TIME = 16;
+	public static final byte REVIVE_SHOW_TIME = 14;
 
 	public static final int ORB_ATK = 0;
 	public static final int ORB_RES = 1;

--- a/util/stage/EStage.java
+++ b/util/stage/EStage.java
@@ -58,6 +58,8 @@ public class EStage extends BattleObj {
 				else
 					rem[i] = data.respawn_0 + (int) (b.r.nextFloat() * (data.respawn_1 - data.respawn_0));
 
+				rem[i]++;
+
 				if (num[i] > 0) {
 					num[i]--;
 


### PR DESCRIPTION
### BROAD
 1. Implemented the walk delay: on the frame entities resume walking status, they don't move, only visually transition to walking animation
 2. Split entity update loop to separate movement from attack: dispatching an entity in one go makes that entity unable to respond (= initiate an attack) to changes in positions of subsequent moved entities. One of the most absurd result of this is an entity with a smaller range can have a frame advantage on a bigger ranged one
 3. Internally ordered entities {[cats], [enemies]}. Because of drawing levels, layers order was being used for general updating too. This was biased. The question is whether in BC for the update loop cats and enemies are mixed together in a single list. If this is were to be case then the finer order of all the entities would make a difference and the game would be much more sensible to chances, if instead factions are not mixed up the inside-faction order doesn't matter because entities react solely to opposite-side entities. One telling experience for this is that moving cats always move in the frame they initiate an attack, while enemy can initiate an attack without moving. But there are also other effects of this clean cut, like the following.
 4. Made possible for cats freeze to block targeted enemies from progressing their attack in the frame they're being frozen: imperfect perfect freeze is now possible
 5. Changed the target for single-attackers from closest to their position to furthest behind into their hitbox
 6. Changed wave stoppers from blocking only the wave that would hit them to block also the one behind
 7. Adjusted waves and surges timings
 8. Adjusted limit position formula for cats / enemies / boss
 9. Adjusted frame-0 and frame-1 spawn enemies and respawn timings

### SPECIFIC
10. Tightened cannons, all of them, ranges, timings, lingering
11. Fixed zombie cannon freeze duration receiving zombie fruit boost
12. Fixed metal cannon damage rounding
13. Adjusted zombie burrowing/reviving transitions timings/interactions with cats
14. Adjusted self-destruct units post attack linger
15. Added summoned spirits enemy base limit
16. Fixed a problem with speed up combos yielding unit steps finer than .25 distance quantization

### VISUAL / NON-MECHANICS
17. Put spirits on same layer (0) so that same frame deaths share same height spirits
18. Cleaned up entity search (1-2-3 letters input get an exact search, >3 letters fuzzy search) 
19. Fixed dojo timer display and capped it to 100 min
20. Fixed app crashing when ordering by min position