### PR TITLE
Implement Inverted Waves (- wave levels)

### DIFF
--- a/battle/attack/AttackSimple.java
+++ b/battle/attack/AttackSimple.java
@@ -157,7 +157,7 @@ public class AttackSimple extends AttackAb {
 			float addp = (dire == 1 ? W_E_INI : W_U_INI) + wid / 2f;
 			float p0 = model.getPos() + dire * addp;
 
-			if (proc.WAVE.lv < 0 && model.getDire() != 0) {
+			if (proc.WAVE.lv < 0) {
 				int corrLv = proc.WAVE.lv * -1;
 				p0 += (((200 * (corrLv))/2f) + ((addp - 100f))) * dire;
 			}

--- a/battle/attack/AttackSimple.java
+++ b/battle/attack/AttackSimple.java
@@ -133,6 +133,12 @@ public class AttackSimple extends AttackAb {
 			int wid = dire == 1 ? W_E_WID : W_U_WID;
 			float addp = (dire == 1 ? W_E_INI : W_U_INI) + wid / 2f;
 			float p0 = model.getPos() + dire * addp;
+
+			if (proc.WAVE.lv < 0 && model.getDire() != 0) {
+				int corrLv = proc.WAVE.lv * -1;
+				p0 += (((200 * (corrLv))/2f) + ((addp - 100f))) * dire;
+			}
+
 			// generate a wave when hits somebody
 
 			ContWaveDef wave = new ContWaveDef(new AttackWave(attacker, this, p0, wid, WT_WAVE), p0, layer, true);

--- a/battle/attack/AttackWave.java
+++ b/battle/attack/AttackWave.java
@@ -17,10 +17,20 @@ public class AttackWave extends AttackAb {
 		waveType = wt;
 		isCounter = a.isCounter;
 		incl = new HashSet<>();
-		if(waveType == WT_MINI)
-			proc.MINIWAVE.lv--;
-		else
-			proc.WAVE.lv--;
+		if (waveType == WT_MINI) {
+			if (proc.MINIWAVE.lv > 0) {
+				proc.MINIWAVE.lv--;
+			} else {
+				proc.MINIWAVE.lv++;
+			}
+		}
+		else {
+			if (proc.WAVE.lv > 0) {
+				proc.WAVE.lv--;
+			} else {
+				proc.WAVE.lv++;
+			}
+		}
 	}
 
 	public AttackWave(Entity e, AttackWave a, float p0, float wid) {
@@ -28,10 +38,20 @@ public class AttackWave extends AttackAb {
 		waveType = a.waveType;
 		isCounter = a.isCounter;
 		incl = a.incl;
-		if(waveType == WT_MINI)
-			proc.MINIWAVE.lv--;
-		else
-			proc.WAVE.lv--;
+		if (waveType == WT_MINI) {
+			if (proc.MINIWAVE.lv > 0) {
+				proc.MINIWAVE.lv--;
+			} else {
+				proc.MINIWAVE.lv++;
+			}
+		}
+		else {
+			if (proc.WAVE.lv > 0) {
+				proc.WAVE.lv--;
+			} else {
+				proc.WAVE.lv++;
+			}
+		}
 	}
 
 	public AttackWave(Entity e, AttackWave a, float pos, float start, float end) {
@@ -39,10 +59,20 @@ public class AttackWave extends AttackAb {
 		waveType = a.waveType;
 		isCounter = a.isCounter;
 		incl = a.incl;
-		if(waveType == WT_MINI)
-			proc.MINIWAVE.lv--;
-		else
-			proc.WAVE.lv--;
+		if (waveType == WT_MINI) {
+			if (proc.MINIWAVE.lv > 0) {
+				proc.MINIWAVE.lv--;
+			} else {
+				proc.MINIWAVE.lv++;
+			}
+		}
+		else {
+			if (proc.WAVE.lv > 0) {
+				proc.WAVE.lv--;
+			} else {
+				proc.WAVE.lv++;
+			}
+		}
 	}
 
 	@Override

--- a/battle/attack/ContWaveDef.java
+++ b/battle/attack/ContWaveDef.java
@@ -52,9 +52,9 @@ public class ContWaveDef extends ContWaveAb {
 		if (!activate)
 			return;
 		if (t == (isMini ? W_MINI_TIME - 1 : W_TIME)) {
-			if (isMini && atk.proc.MINIWAVE.lv > 0)
+			if (isMini && atk.proc.MINIWAVE.lv != 0)
 				nextWave();
-			else if (!isMini && atk.getProc().WAVE.lv > 0)
+			else if (!isMini && atk.getProc().WAVE.lv != 0)
 				nextWave();
 		}
 		if (t == attack) {
@@ -77,7 +77,12 @@ public class ContWaveDef extends ContWaveAb {
 	@Override
 	protected void nextWave() {
 		int dire = atk.model.getDire();
-		float np = pos + W_PROG * dire;
+		float np = 0;
+		if(atk.proc.WAVE.lv < 0) {
+			np = pos - W_PROG * dire;
+		} else {
+			np = pos + W_PROG * dire;
+		}
 		int wid = dire == 1 ? W_E_WID : W_U_WID;
 		new ContWaveDef(new AttackWave(atk.attacker, atk, np, wid), np, layer, false, waves);
 	}

--- a/util/lang/Editors.java
+++ b/util/lang/Editors.java
@@ -306,7 +306,7 @@ public class Editors {
 
 		map().put("WAVE", new EditControl<>(Proc.WAVE.class, (t) -> {
 			t.prob = MathUtil.clip(t.prob, 0, 100);
-			t.lv = MathUtil.clip(t.lv, 1, 20);
+			t.lv = t.lv != 0 ? t.lv : 1;
 			if (t.prob == 0)
 				t.lv = 0;
 		}));
@@ -586,7 +586,7 @@ public class Editors {
 				t.lv = 0;
 				t.multi = 0;
 			} else {
-				t.lv = MathUtil.clip(t.lv, 1, 20);
+				t.lv = MathUtil.clip(t.lv, 1, 20);;
 
 				if(t.multi == 0)
 					t.multi = 20;

--- a/util/lang/assets/proc.json
+++ b/util/lang/assets/proc.json
@@ -79,7 +79,7 @@
         "abbr_name": "wave",
         "full_name": "Wave",
         "tooltip": null,
-        "format": "(prob)% chance to create a Lv.(lv) wave attack",
+        "format": "(prob)% chance to create a Lv.(_abs(lv)) [(lv<0){inverted }]wave attack",
         "class": {
             "prob": {
                 "name": "chance",
@@ -87,7 +87,7 @@
             },
             "lv": {
                 "name": "level",
-                "tooltip": null
+                "tooltip": "Set to negative for an inverted wave that moves from end to start point"
             }
         }
     },
@@ -983,7 +983,7 @@
         "abbr_name" : "mini-wave",
         "full_name" : "Mini-Wave",
         "tooltip" : "Creates small wave which moves twice faster than normal wave with dynamic damage multiplication parameter",
-        "format" : "(prob)% chance to create a lv.(lv) mini-wave [(multi!=20){(_left)Gives target (multi)% of activator's damage(_right)}]",
+        "format" : "(prob)% chance to create a Lv.(_abs(lv)) [(lv<0){inverted }]mini-wave [(multi!=20){(_left)Gives target (multi)% of activator's damage(_right)}]",
         "class" : {
             "prob" : {
                 "name" : "chance",
@@ -991,7 +991,7 @@
             },
             "lv" : {
                 "name" : "level",
-                "tooltip" : null
+                "tooltip" : "Set to negative for an inverted mini-wave that moves from end to start point"
             },
             "multi" : {
                 "name" : "multi",

--- a/util/stage/Stage.java
+++ b/util/stage/Stage.java
@@ -76,7 +76,7 @@ public class Stage extends Data
 		len = 3000;
 		health = 60000;
 		max = 8;
-		names.put("Stage " + (getCont().list.size() + 1));
+		names.put("stage " + getCont().list.size());
 		lim = new Limit();
 		data = new SCDef(0);
 	}
@@ -86,7 +86,7 @@ public class Stage extends Data
 		len = 3000;
 		health = 60000;
 		max = 8;
-		names.put("Stage " + (sm.list.size() + 1));
+		names.put("stage " + sm.list.size());
 		lim = new Limit();
 		data = new SCDef(0);
 	}

--- a/util/stage/Stage.java
+++ b/util/stage/Stage.java
@@ -76,7 +76,7 @@ public class Stage extends Data
 		len = 3000;
 		health = 60000;
 		max = 8;
-		names.put("stage " + getCont().list.size());
+		names.put("Stage " + (getCont().list.size() + 1));
 		lim = new Limit();
 		data = new SCDef(0);
 	}
@@ -86,7 +86,7 @@ public class Stage extends Data
 		len = 3000;
 		health = 60000;
 		max = 8;
-		names.put("stage " + sm.list.size());
+		names.put("Stage " + (sm.list.size() + 1));
 		lim = new Limit();
 		data = new SCDef(0);
 	}


### PR DESCRIPTION
Implements the "inverted waves" custom content feature, which allows attacks with negative wave levels that move backwards from the end point to the start point. Currently it does not function for Mini-Waves.

This has also removed the wave level cap, which can be re-implemented if you want to re-implement it.