### PR TITLE
Critical: Emergency reversion of Moving Attack IDs

### DIFF
--- a/battle/attack/AttackSimple.java
+++ b/battle/attack/AttackSimple.java
@@ -144,7 +144,7 @@ public class AttackSimple extends AttackAb {
 			MOVEWAVE mw = proc.MOVEWAVE;
 			int dire = model.getDire();
 			float p0 = model.getPos() + dire * mw.dis;
-			new ContMove(this, p0, mw.width, mw.speed, 1, mw.time, mw.itv, layer, mw.id);
+			new ContMove(this, p0, mw.width, mw.speed, 1, mw.time, mw.itv, layer);
 			return;
 		}
 		for (AbEntity e : capt) {

--- a/battle/attack/ContMove.java
+++ b/battle/attack/ContMove.java
@@ -7,13 +7,13 @@ import common.system.fake.FakeGraphics;
 
 public class ContMove extends ContAb {
 
-	private final int itv, move, ran, rep, id;
+	private final int itv, move, ran, rep;
 	private int t, rem, rept;
 	private final AttackWave atk;
 	private boolean tempAtk;
 
 	/**
-	 * conf: range, move, itrv, tot, rept, layer, id
+	 * conf: range, move, itrv, tot, rept,layer
 	 */
 	public ContMove(AttackSimple as, float p, int... conf) {
 		super(as.model.b, p, conf[5]);
@@ -24,7 +24,6 @@ public class ContMove extends ContAb {
 		ran = conf[0];
 		rep = conf[4];
 		rept = rep > 0 ? rep : -1;
-		id = conf[6];
 		atk = new AttackWave(as.attacker, as, 0, 0, WT_MOVE);
 	}
 

--- a/battle/entity/Entity.java
+++ b/battle/entity/Entity.java
@@ -1543,16 +1543,13 @@ public abstract class Entity extends AbEntity {
 				dmg = dmg * (100 - getProc().IMUWAVE.mult) / 100;
 		}
 
-		// Sorry for nesting! - Ramen Cat
 		if ((atk.waveType & WT_MOVE) > 0) {
-			if ((atk.getProc().MOVEWAVE.id == getProc().IMUMOVING.id && getProc().IMUMOVING.useIds) || (!getProc().IMUMOVING.useIds)) {
-				if (getProc().IMUMOVING.mult > 0)
-					anim.getEff(P_WAVE);
-				if (getProc().IMUMOVING.mult == 100)
-					return;
-				else
-					dmg = dmg * (100 - getProc().IMUMOVING.mult) / 100;
-			}
+			if (getProc().IMUMOVING.mult > 0)
+				anim.getEff(P_WAVE);
+			if (getProc().IMUMOVING.mult == 100)
+				return;
+			else
+				dmg = dmg * (100 - getProc().IMUMOVING.mult) / 100;
 		}
 
 		if ((atk.waveType & (WT_VOLC | WT_MIVC)) > 0) {

--- a/util/Data.java
+++ b/util/Data.java
@@ -170,8 +170,6 @@ public class Data {
 			public int dis;
 			@Order(5)
 			public int itv;
-			@Order(6)
-			public int id;
 		}
 
 		@JsonClass(noTag = NoTag.LOAD)
@@ -623,15 +621,6 @@ public class Data {
 			@Order(0)
 			public int mult;
 		}
-		@JsonClass(noTag = NoTag.LOAD) // Similar to WAVEI. Supports ids
-		public static class MOVEI extends ProcItem {
-			@Order(0)
-			public int mult;
-			@Order(1)
-			public int id;
-			@Order(2)
-			public boolean useIds;
-		}
 
 		@JsonClass(noTag = NoTag.LOAD)
 		public static class CANNI extends ProcItem {
@@ -802,7 +791,7 @@ public class Data {
 		@Order(37)
 		public final IMU IMUPOIATK = new IMU();
 		@Order(38)
-		public final MOVEI IMUMOVING = new MOVEI();
+		public final WAVEI IMUMOVING = new WAVEI();
 		@Order(39)
 		public final CANNI IMUCANNON = new CANNI();
 		@Order(40)

--- a/util/lang/Editors.java
+++ b/util/lang/Editors.java
@@ -279,7 +279,6 @@ public class Editors {
 		});
 
 		EditControl<Proc.WAVEI> wavei = new EditControl<>(Proc.WAVEI.class, (t) -> t.mult = Math.min(t.mult, 100));
-		EditControl<Proc.MOVEI> movei = new EditControl<>(Proc.MOVEI.class, (t) -> t.mult = Math.min(t.mult, 100));
 
 		map().put("KB", new EditControl<>(Proc.PTD.class, (t) -> {
 			t.prob = MathUtil.clip(t.prob, 0, 100);
@@ -616,7 +615,7 @@ public class Editors {
 
 		map().put("IMUSEAL", imu);
 
-		map().put("IMUMOVING", movei);
+		map().put("IMUMOVING", wavei);
 
 		map().put("IMUCANNON", new EditControl<>(Proc.CANNI.class, (t) -> {
 			t.mult = Math.min(t.mult, 100);

--- a/util/lang/assets/proc.json
+++ b/util/lang/assets/proc.json
@@ -604,7 +604,7 @@
         "full_name": "Moving Attack",
         "tooltip": null,
         "format": [
-            "(prob)% chance to have moving hit box[(id!=0){ with an ID of (id)}], ",
+            "(prob)% chance to have moving hit box, ",
             "originated at a distance of (dis) from this entity ",
             "with (width) widths, ",
             " (speed) speed, and (_dispTime(itv)) interval for (_dispTime(time))"
@@ -633,10 +633,6 @@
             "itv": {
                 "name": "interval",
                 "tooltip": null
-            },
-            "id": {
-                "name": "id",
-                "tooltip": "sets the ID of moving attack, allowing for type-based resistance discrimination"
             }
         }
     },
@@ -644,19 +640,11 @@
         "abbr_name": "imu. Move",
         "full_name": "Immune/Resistant to Moving Atk",
         "tooltip": null,
-        "format": "[(mult==100){Immune}(mult<100&mult>0){Resistant}(mult<0){Weak}] to Moving Attacks[(useIds){ with an ID of (id)}][(mult<100&mult>0){ (_left)Decreases damage taken by (mult)%(_right)}(mult<0){ (_left)Increases damage taken by (_abs(mult))%(_right)}]",
+        "format": "[(mult==100){Immune}(mult<100&mult>0){Resistant}(mult<0){Weak}] to Moving Attacks[(mult<100&mult>0){ (_left)Decreases damage taken by (mult)%(_right)}(mult<0){ (_left)Increases damage taken by (_abs(mult))%(_right)}]",
         "class": {
             "mult": {
                 "name": "percent",
                 "tooltip": "Set negative to make this unit weak to the effect"
-            },
-            "id": {
-                "name": "id",
-                "tooltip": "Non-zero values will only make resistance apply to moving attacks with this id, if id checks are enabled"
-            },
-            "useIds": {
-                "name": "use ids",
-                "tooltip": "Enable ID checks"
             }
         }
     },


### PR DESCRIPTION
Moving Attack IDs have been found to cause serious problems with the JSON encoder for saving.

This reverts commit c2f58e691fb3377e82d077f8f6b4e3910aca8548.