### PR TITLE
Attempt to fix animation rename crash

### DIFF
--- a/pack/Source.java
+++ b/pack/Source.java
@@ -335,7 +335,7 @@ public abstract class Source {
 
 			CommonStatic.ctx.noticeErr(
 					() -> Context.delete(CommonStatic.ctx.getWorkspaceFile("./" + id.pack + "/" + id.base + "/" + id.id)),
-					ErrType.ERROR, "failed to delete animation: " + id);
+					ErrType.WARN, "failed to delete/rename animation: " + id + ", duplicates may appear");
 		}
 
 		public void saveAll() {


### PR DESCRIPTION
This is a naive approach to fix the issue of animation renaming/deleting causing files to be completely erased when they shouldn't be

Duplicates appearing is better than users losing work to a crash that's all but guaranteed to otherwise be inconsequential