### PR TITLE
Custom Sound Effects

### DIFF
--- a/CommonStatic.java
+++ b/CommonStatic.java
@@ -9,6 +9,7 @@ import common.pack.Identifier;
 import common.pack.UserProfile;
 import common.system.VImg;
 import common.system.fake.FakeImage;
+import common.system.files.VFile;
 import common.util.Data;
 import common.util.anim.ImgCut;
 import common.util.anim.MaModel;
@@ -101,6 +102,8 @@ public class CommonStatic {
 		// bg effect
 		public final Map<Integer, BackgroundEffect> bgEffects = new HashMap<>();
 
+		// custom sfx
+		public VFile[] assetSfx = new VFile[1];
 	}
 
 	@JsonClass(noTag = NoTag.LOAD)

--- a/battle/entity/Entity.java
+++ b/battle/entity/Entity.java
@@ -24,6 +24,7 @@ import common.util.pack.Soul;
 import common.util.stage.StageLimit;
 import common.util.unit.Level;
 import common.util.unit.Trait;
+import io.BCMusic;
 
 import java.util.*;
 
@@ -1564,6 +1565,8 @@ public abstract class Entity extends AbEntity {
 	@Override
 	public boolean damaged(AttackAb atk) {
 		damageTaken += atk.atk;
+
+		BCMusic.setAssetSE(0);
 
 		int dmg = getDamage(atk, atk.atk);
 		boolean proc = true;

--- a/util/Res.java
+++ b/util/Res.java
@@ -9,6 +9,7 @@ import common.system.VImg;
 import common.system.fake.FakeGraphics;
 import common.system.fake.FakeImage;
 import common.system.fake.ImageBuilder;
+import common.system.files.VFile;
 import common.util.anim.ImgCut;
 
 public class Res extends ImgCore {
@@ -140,6 +141,12 @@ public class Res extends ImgCore {
 		aux.dummyTrait = new VImg("./org/page/Trait.png");
 		readAbiIcon();
 		readBattle();
+		readSound();
+	}
+
+	private static void readSound() {
+		BCAuxAssets aux = CommonStatic.getBCAssets();
+		aux.assetSfx[0] = VFile.get("./org/audio/test/440test.ogg");
 	}
 
 	private static int[] getLab(long cost) {


### PR DESCRIPTION
Allows BCU to load sound effects directly from the asset data paths rather than by index.